### PR TITLE
Having make clean seems (seems) to break the build process

### DIFF
--- a/setup-openresty
+++ b/setup-openresty
@@ -704,7 +704,7 @@ if test ! -f "$PREFIX/luajit/bin/luarocks" ; then
   ./configure \
     --prefix=$PREFIX/luajit \
     --with-lua=$PREFIX/luajit >> $LUAROCKS_LOGFILE 2>&1
-  make >> $LUAROCKS_LOGFILE 2>&1
+  make build >> $LUAROCKS_LOGFILE 2>&1
   make bootstrap >> $LUAROCKS_LOGFILE 2>&1
   cat <<EOF >$PREFIX/luajit/etc/luarocks/config-5.1.lua
 rocks_trees = {

--- a/setup-openresty
+++ b/setup-openresty
@@ -700,11 +700,11 @@ if test ! -f "$PREFIX/luajit/bin/luarocks" ; then
   LUAROCKS_LOGFILE=$(mktemp)
   printf "Installing Luarocks ${LUAROCKS_VERSION} (log at ${LUAROCKS_LOGFILE})\n" | tee -a $LUAROCKS_LOGFILE
   pushd /src/luarocks-${LUAROCKS_VERSION}
+  make clean >/dev/null 2>&1 || true
   ./configure \
     --prefix=$PREFIX/luajit \
     --with-lua=$PREFIX/luajit >> $LUAROCKS_LOGFILE 2>&1
-  make clean >/dev/null 2>&1 || true
-  make build >> $LUAROCKS_LOGFILE 2>&1
+  make >> $LUAROCKS_LOGFILE 2>&1
   make bootstrap >> $LUAROCKS_LOGFILE 2>&1
   cat <<EOF >$PREFIX/luajit/etc/luarocks/config-5.1.lua
 rocks_trees = {


### PR DESCRIPTION
I'm not sure if this is the proper way to this, no lua (or luarocks) expert here, but the build process fails with:

```
Installing Luarocks 3.0.3 (log at /tmp/tmp.ae8ChXHMsy)

Configuring LuaRocks version 3.0.3...

Lua version detected: 5.1
Lua interpreter found: /opt/openresty-rtmp/luajit/bin/luajit
lua.h found: /opt/openresty-rtmp/luajit/include/lua.h
unzip found in PATH: /usr/bin

Done configuring.

LuaRocks will be installed at......: /opt/openresty-rtmp/luajit
LuaRocks will install rocks at.....: /opt/openresty-rtmp/luajit
LuaRocks configuration directory...: /opt/openresty-rtmp/luajit/etc/luarocks
Using Lua from.....................: /opt/openresty-rtmp/luajit

* Type make and make install:
  to install to /opt/openresty-rtmp/luajit as usual.
* Type make bootstrap:
  to install LuaRocks into /opt/openresty-rtmp/luajit as a rock.

Please run the ./configure script before building.

make: *** No rule to make target 'config.unix', needed by 'luarocks'.  Stop.
```

Moving `make clean` higher fixes the build process for me?